### PR TITLE
Use `pip` as a solver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
           pixi add "python=${{ matrix.python-version }}.*=*cpython*"
           pixi run dev
           pixi run conda info
+      - name: Configure conda
+        run: |
+          echo "channels: [conda-forge]" > .pixi/envs/default/.condarc
       - name: Patch history file (temporary)
         run: echo "//fix" > .pixi/envs/default/conda-meta/history 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,5 @@ jobs:
         run: echo "//fix" > .pixi/envs/default/conda-meta/history 
       - name: Run tests
         run: pixi run test --basetemp=${{ runner.os == 'Windows' && 'D:\\temp' || runner.temp }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: always()
-        timeout-minutes: 60
       - name: Build recipe
         run: pixi run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Patch history file (temporary)
         run: echo "//fix" > .pixi/envs/default/conda-meta/history 
       - name: Run tests
-        run: pixi run test
+        run: pixi run test --basetemp=${{ runner.os == 'Windows' && 'D:\\temp' || runner.temp }}
       - name: Build recipe
         run: pixi run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,5 +53,9 @@ jobs:
         run: echo "//fix" > .pixi/envs/default/conda-meta/history 
       - name: Run tests
         run: pixi run test --basetemp=${{ runner.os == 'Windows' && 'D:\\temp' || runner.temp }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: always()
+        timeout-minutes: 15
       - name: Build recipe
         run: pixi run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,8 @@ jobs:
           pixi add "python=${{ matrix.python-version }}.*=*cpython*"
           pixi run dev
           pixi run conda info
+      - name: Patch history file (temporary)
+        run: echo "//fix" > .pixi/envs/default/conda-meta/history 
       - name: Run tests
         run: pixi run test
       - name: Build recipe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,6 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: always()
-        timeout-minutes: 15
+        timeout-minutes: 60
       - name: Build recipe
         run: pixi run build

--- a/conda_pip/cli.py
+++ b/conda_pip/cli.py
@@ -120,7 +120,7 @@ def execute(args: argparse.Namespace) -> int:
 
     if not args.yes and not args.json:
         if conda_match_specs or pypi_specs:
-            confirm_yn(dry_run=args.dry_run)
+            confirm_yn(dry_run=False)  # we let conda handle the dry-run exit below
         else:
             print("Nothing to do.", file=sys.stderr)
             return 0

--- a/conda_pip/cli.py
+++ b/conda_pip/cli.py
@@ -87,6 +87,7 @@ def execute(args: argparse.Namespace) -> int:
             channel=args.conda_channel,
             backend=args.backend,
             prefix=prefix,
+            force_reinstall=args.force_reinstall,
         )
 
     conda_match_specs = []

--- a/conda_pip/cli.py
+++ b/conda_pip/cli.py
@@ -1,6 +1,8 @@
 """
 conda pip subcommand for CLI
 """
+from __future__ import annotations
+
 import argparse
 import os
 import sys

--- a/conda_pip/cli.py
+++ b/conda_pip/cli.py
@@ -17,6 +17,8 @@ logger = getLogger(f"conda.{__name__}")
 
 
 def configure_parser(parser: argparse.ArgumentParser):
+    from .dependencies import BACKENDS
+
     add_parser_help(parser)
     add_parser_prefix(parser)
     add_output_and_prompt_options(parser)
@@ -51,6 +53,13 @@ def configure_parser(parser: argparse.ArgumentParser):
         default="conda-forge",
         help="Where to look for conda dependencies.",
     )
+    install.add_argument(
+        "--backend",
+        metavar="TOOL",
+        default="pip",
+        choices=BACKENDS,
+        help="Which tool to use for PyPI packaging dependency resolution.",
+    )
     install.add_argument("packages", metavar="package", nargs="+")
 
 
@@ -74,7 +83,7 @@ def execute(args: argparse.Namespace) -> None:
             *packages_to_process,
             prefer_on_conda=not args.force_with_pip,
             channel=args.conda_channel,
-            backend="pip",
+            backend=args.backend,
             prefix=prefix,
         )
 

--- a/conda_pip/cli.py
+++ b/conda_pip/cli.py
@@ -73,6 +73,7 @@ def execute(args: argparse.Namespace) -> None:
             *packages_to_process,
             prefer_on_conda=not args.force_with_pip,
             channel=args.conda_channel,
+            backend="pip",
         )
 
     conda_match_specs = []

--- a/conda_pip/cli.py
+++ b/conda_pip/cli.py
@@ -63,7 +63,7 @@ def configure_parser(parser: argparse.ArgumentParser):
     install.add_argument("packages", metavar="package", nargs="+")
 
 
-def execute(args: argparse.Namespace) -> None:
+def execute(args: argparse.Namespace) -> int:
     from conda.common.io import Spinner
     from conda.models.match_spec import MatchSpec
     from .dependencies import analyze_dependencies

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -1,9 +1,8 @@
-"""
-"""
+""" """
+
 from logging import getLogger
 from collections import defaultdict
 from conda.models.match_spec import MatchSpec
-from grayskull.base.pkg_info import is_pkg_available
 
 logger = getLogger(f"conda.{__name__}")
 
@@ -12,20 +11,21 @@ BACKENDS = (
     "pip",
 )
 
+
 def analyze_dependencies(
     *packages: str,
     prefer_on_conda=True,
     channel="conda-forge",
-    backend="grayskull",
+    backend="pip",
     prefix=None,
-):
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     conda_deps = defaultdict(list)
     needs_analysis = []
     for package in packages:
         match_spec = MatchSpec(package)
         pkg_name = match_spec.name
         # pkg_version = match_spec.version
-        if prefer_on_conda and is_pkg_available(pkg_name, channel=channel):
+        if prefer_on_conda and _is_pkg_on_conda(pkg_name, channel=channel):
             # TODO: check if version is available too
             logger.info("Package %s is available on %s. Skipping analysis.", pkg_name, channel)
             conda_deps[pkg_name].append(package)
@@ -44,9 +44,18 @@ def analyze_dependencies(
     elif backend == "pip":
         from .pip import _analyze_with_pip
 
-        found_conda_deps, pypi_deps = _analyze_with_pip(
-            *needs_analysis, prefer_on_conda=prefer_on_conda, channel=channel, prefix=prefix,
+        python_deps, pypi_deps = _analyze_with_pip(
+            *needs_analysis,
+            prefer_on_conda=prefer_on_conda,
+            channel=channel,
+            prefix=prefix,
         )
+        more_conda_deps, pypi_deps = _classify_dependencies(
+            pypi_deps,
+            prefer_on_conda=prefer_on_conda,
+            channel=channel,
+        )
+        conda_deps.update({**python_deps, **more_conda_deps})
     else:
         raise ValueError(f"Unknown backend {backend}")
 
@@ -55,6 +64,30 @@ def analyze_dependencies(
     # deduplicate
     conda_deps = {name: list(dict.fromkeys(specs)) for name, specs in conda_deps.items()}
     pypi_deps = {name: list(dict.fromkeys(specs)) for name, specs in pypi_deps.items()}
-    print(conda_deps)
-    print(pypi_deps)
     return conda_deps, pypi_deps
+
+
+def _classify_dependencies(
+    deps_from_pypi,
+    prefer_on_conda: bool = True,
+    channel: str = "conda-forge",
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    pypi_deps = defaultdict(list)
+    conda_deps = defaultdict(list)
+    for depname, deps in deps_from_pypi.items():
+        if prefer_on_conda and _is_pkg_on_conda(depname, channel=channel):
+            conda_deps[depname].extend(deps)  # TODO: Map pypi name to conda name(s)
+        else:
+            pypi_deps[depname].extend(deps)
+    return conda_deps, pypi_deps
+
+
+def _is_pkg_on_conda(spec: str, channel: str="conda-forge"):
+    # TODO: Do this without grayskull
+    from grayskull.base.pkg_info import is_pkg_available
+
+    return is_pkg_available(spec, channel=channel)
+
+def _pypi_name_to_conda_name(spec: str, channel: str="conda-forge"):
+    # TODO: implement mapping
+    return spec

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -1,8 +1,14 @@
 """ """
 
+from __future__ import annotations
+
+import os
 from logging import getLogger
 from collections import defaultdict
+from typing import Literal
+
 from conda.models.match_spec import MatchSpec
+
 
 logger = getLogger(f"conda.{__name__}")
 
@@ -14,10 +20,11 @@ BACKENDS = (
 
 def analyze_dependencies(
     *packages: str,
-    prefer_on_conda=True,
-    channel="conda-forge",
-    backend="pip",
-    prefix=None,
+    prefer_on_conda: bool = True,
+    channel: str = "conda-forge",
+    backend: Literal["grayskull", "pip"] = "pip",
+    prefix: str | os.PathLike | None =None,
+    force_reinstall: bool = False,
 ) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     conda_deps = defaultdict(list)
     needs_analysis = []
@@ -46,21 +53,21 @@ def analyze_dependencies(
 
         python_deps, pypi_deps = _analyze_with_pip(
             *needs_analysis,
-            prefer_on_conda=prefer_on_conda,
-            channel=channel,
             prefix=prefix,
+            force_reinstall=force_reinstall,
         )
-        more_conda_deps, pypi_deps = _classify_dependencies(
+        found_conda_deps, pypi_deps = _classify_dependencies(
             pypi_deps,
             prefer_on_conda=prefer_on_conda,
             channel=channel,
         )
-        conda_deps.update({**python_deps, **more_conda_deps})
+        found_conda_deps.update(python_deps)
     else:
         raise ValueError(f"Unknown backend {backend}")
 
     for name, specs in found_conda_deps.items():
         conda_deps[name].extend(specs)
+
     # deduplicate
     conda_deps = {name: list(dict.fromkeys(specs)) for name, specs in conda_deps.items()}
     pypi_deps = {name: list(dict.fromkeys(specs)) for name, specs in pypi_deps.items()}
@@ -68,7 +75,7 @@ def analyze_dependencies(
 
 
 def _classify_dependencies(
-    deps_from_pypi,
+    deps_from_pypi: dict[str, list[str]],
     prefer_on_conda: bool = True,
     channel: str = "conda-forge",
 ) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
@@ -76,18 +83,24 @@ def _classify_dependencies(
     conda_deps = defaultdict(list)
     for depname, deps in deps_from_pypi.items():
         if prefer_on_conda and _is_pkg_on_conda(depname, channel=channel):
-            conda_deps[depname].extend(deps)  # TODO: Map pypi name to conda name(s)
+            conda_depname = _pypi_name_to_conda_name(depname, channel=channel)
+            deps_mapped_to_conda = [
+                _pypi_name_to_conda_name(dep, channel=channel)
+                for dep in deps
+            ]
+            conda_deps[conda_depname].extend(deps_mapped_to_conda)
         else:
             pypi_deps[depname].extend(deps)
     return conda_deps, pypi_deps
 
 
-def _is_pkg_on_conda(spec: str, channel: str="conda-forge"):
+def _is_pkg_on_conda(spec: str, channel: str = "conda-forge"):
     # TODO: Do this without grayskull
     from grayskull.base.pkg_info import is_pkg_available
 
     return is_pkg_available(spec, channel=channel)
 
-def _pypi_name_to_conda_name(spec: str, channel: str="conda-forge"):
+
+def _pypi_name_to_conda_name(spec: str, channel: str = "conda-forge"):
     # TODO: implement mapping
     return spec

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -24,7 +24,7 @@ def analyze_dependencies(
         if prefer_on_conda and is_pkg_available(pkg_name, channel=channel):
             # TODO: check if version is available too
             logger.info("Package %s is available on %s. Skipping analysis.", pkg_name, channel)
-            conda_deps[pkg_name].append({package})
+            conda_deps[pkg_name].append(package)
             continue
         needs_analysis.append(package)
 
@@ -51,4 +51,6 @@ def analyze_dependencies(
     # deduplicate
     conda_deps = {name: list(dict.fromkeys(specs)) for name, specs in conda_deps.items()}
     pypi_deps = {name: list(dict.fromkeys(specs)) for name, specs in pypi_deps.items()}
+    print(conda_deps)
+    print(pypi_deps)
     return conda_deps, pypi_deps

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -7,6 +7,10 @@ from grayskull.base.pkg_info import is_pkg_available
 
 logger = getLogger(f"conda.{__name__}")
 
+BACKENDS = (
+    "grayskull",
+    "pip",
+)
 
 def analyze_dependencies(
     *packages: str,

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -3,19 +3,28 @@
 from __future__ import annotations
 
 import os
-from logging import getLogger
 from collections import defaultdict
+from logging import getLogger
+from functools import lru_cache
+from io import BytesIO
 from typing import Literal
 
+import requests
 from conda.models.match_spec import MatchSpec
+from conda_libmamba_solver.index import LibMambaIndexHelper as Index
+from ruamel.yaml import YAML
 
-
+yaml = YAML(typ="safe")
 logger = getLogger(f"conda.{__name__}")
 
 BACKENDS = (
     "grayskull",
     "pip",
 )
+NAME_MAPPINGS = {
+    "grayskull": "https://github.com/conda/grayskull/raw/main/grayskull/strategy/config.yaml",
+    "cf-graph-countyfair": "https://github.com/regro/cf-graph-countyfair/raw/master/mappings/pypi/grayskull_pypi_mapping.yaml",
+}
 
 
 def analyze_dependencies(
@@ -23,7 +32,7 @@ def analyze_dependencies(
     prefer_on_conda: bool = True,
     channel: str = "conda-forge",
     backend: Literal["grayskull", "pip"] = "pip",
-    prefix: str | os.PathLike | None =None,
+    prefix: str | os.PathLike | None = None,
     force_reinstall: bool = False,
 ) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     conda_deps = defaultdict(list)
@@ -35,7 +44,8 @@ def analyze_dependencies(
         if prefer_on_conda and _is_pkg_on_conda(pkg_name, channel=channel):
             # TODO: check if version is available too
             logger.info("Package %s is available on %s. Skipping analysis.", pkg_name, channel)
-            conda_deps[pkg_name].append(package)
+            conda_spec = _pypi_spec_to_conda_spec(package)
+            conda_deps[pkg_name].append(conda_spec)
             continue
         needs_analysis.append(package)
 
@@ -83,24 +93,63 @@ def _classify_dependencies(
     conda_deps = defaultdict(list)
     for depname, deps in deps_from_pypi.items():
         if prefer_on_conda and _is_pkg_on_conda(depname, channel=channel):
-            conda_depname = _pypi_name_to_conda_name(depname, channel=channel)
-            deps_mapped_to_conda = [
-                _pypi_name_to_conda_name(dep, channel=channel)
-                for dep in deps
-            ]
+            conda_depname = _pypi_spec_to_conda_spec(depname, channel=channel).name
+            deps_mapped_to_conda = [_pypi_spec_to_conda_spec(dep, channel=channel) for dep in deps]
             conda_deps[conda_depname].extend(deps_mapped_to_conda)
         else:
             pypi_deps[depname].extend(deps)
     return conda_deps, pypi_deps
 
 
-def _is_pkg_on_conda(spec: str, channel: str = "conda-forge"):
-    # TODO: Do this without grayskull
-    from grayskull.base.pkg_info import is_pkg_available
+@lru_cache(maxsize=None)
+def _is_pkg_on_conda(pypi_spec: str, channel: str = "conda-forge"):
+    """
+    Given a PyPI spec (name, version), try to find it on conda-forge.
+    """
+    conda_spec = _pypi_spec_to_conda_spec(pypi_spec)
+    index = Index(channels=[channel])
+    records = index.search(conda_spec)
+    return bool(records)
 
-    return is_pkg_available(spec, channel=channel)
+
+@lru_cache(maxsize=None)
+def _pypi_to_conda_mapping(source="grayskull"):
+    try:
+        url = NAME_MAPPINGS[source]
+    except KeyError as exc:
+        raise ValueError(f"Invalid source {source}. Allowed: {NAME_MAPPINGS.keys()}") from exc
+    r = requests.get(url)
+    try:
+        r.raise_for_status()
+    except requests.HTTPError as exc:
+        logger.debug("Could not fetch mapping %s", url, exc_info=exc)
+        return {}
+    stream = BytesIO(r.content)
+    stream.seek(0)
+    return yaml.load(stream)
 
 
-def _pypi_name_to_conda_name(spec: str, channel: str = "conda-forge"):
-    # TODO: implement mapping
+@lru_cache(maxsize=None)
+def _pypi_spec_to_conda_spec(spec: str, channel: str = "conda-forge"):
+    """
+    Tries to find the conda equivalent of a PyPI name. For that it relies
+    on known mappings (see `_pypi_to_conda_mapping`). If the PyPI name is
+    not found in any of the mappings, we assume the name is the same.
+
+    Note that we don't currently have a way to disambiguate two different
+    projects that have the same name in PyPI and conda-forge (e.g. quetz, pixi).
+    We could improve this with API calls to metadata servers and compare sources,
+    but this is not currently implemented or even feasible.
+    """
+    assert channel == "conda-forge", "Only channel=conda-forge is supported for now"
+    match_spec = MatchSpec(spec)
+    conda_name = pypi_name = match_spec.name
+    for source in NAME_MAPPINGS:
+        mapping = _pypi_to_conda_mapping(source)
+        if not mapping:
+            continue
+        entry = mapping.get(pypi_name, {})
+        conda_name = entry.get("conda_forge") or entry.get("conda_name") or pypi_name
+        if conda_name != pypi_name:  # we found a match!
+            return str(MatchSpec(match_spec, name=conda_name))
     return spec

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -1,14 +1,10 @@
 """
 """
-from logging import getLogger, ERROR
+from logging import getLogger
 from collections import defaultdict
 from conda.models.match_spec import MatchSpec
 from grayskull.base.pkg_info import is_pkg_available
 
-getLogger("grayskull").setLevel(ERROR)
-getLogger("souschef").setLevel(ERROR)
-getLogger("requests").setLevel(ERROR)
-getLogger("urllib3").setLevel(ERROR)
 logger = getLogger(f"conda.{__name__}")
 
 
@@ -17,6 +13,7 @@ def analyze_dependencies(
     prefer_on_conda=True,
     channel="conda-forge",
     backend="grayskull",
+    prefix=None,
 ):
     conda_deps = defaultdict(list)
     needs_analysis = []
@@ -27,7 +24,7 @@ def analyze_dependencies(
         if prefer_on_conda and is_pkg_available(pkg_name, channel=channel):
             # TODO: check if version is available too
             logger.info("Package %s is available on %s. Skipping analysis.", pkg_name, channel)
-            conda_deps[pkg_name].append(f"{channel}::{package}")
+            conda_deps[pkg_name].append({package})
             continue
         needs_analysis.append(package)
 
@@ -44,7 +41,7 @@ def analyze_dependencies(
         from .pip import _analyze_with_pip
 
         found_conda_deps, pypi_deps = _analyze_with_pip(
-            *needs_analysis, prefer_on_conda=prefer_on_conda, channel=channel
+            *needs_analysis, prefer_on_conda=prefer_on_conda, channel=channel, prefix=prefix,
         )
     else:
         raise ValueError(f"Unknown backend {backend}")

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -1,0 +1,57 @@
+"""
+"""
+from logging import getLogger, ERROR
+from collections import defaultdict
+from conda.models.match_spec import MatchSpec
+from grayskull.base.pkg_info import is_pkg_available
+
+getLogger("grayskull").setLevel(ERROR)
+getLogger("souschef").setLevel(ERROR)
+getLogger("requests").setLevel(ERROR)
+getLogger("urllib3").setLevel(ERROR)
+logger = getLogger(f"conda.{__name__}")
+
+
+def analyze_dependencies(
+    *packages: str,
+    prefer_on_conda=True,
+    channel="conda-forge",
+    backend="grayskull",
+):
+    conda_deps = defaultdict(list)
+    needs_analysis = []
+    for package in packages:
+        match_spec = MatchSpec(package)
+        pkg_name = match_spec.name
+        # pkg_version = match_spec.version
+        if prefer_on_conda and is_pkg_available(pkg_name, channel=channel):
+            # TODO: check if version is available too
+            logger.info("Package %s is available on %s. Skipping analysis.", pkg_name, channel)
+            conda_deps[pkg_name].append(f"{channel}::{package}")
+            continue
+        needs_analysis.append(package)
+
+    if not needs_analysis:
+        return conda_deps, {}
+
+    if backend == "grayskull":
+        from .grayskull import _analyze_with_grayskull
+
+        found_conda_deps, pypi_deps = _analyze_with_grayskull(
+            *needs_analysis, prefer_on_conda=prefer_on_conda, channel=channel
+        )
+    elif backend == "pip":
+        from .pip import _analyze_with_pip
+
+        found_conda_deps, pypi_deps = _analyze_with_pip(
+            *needs_analysis, prefer_on_conda=prefer_on_conda, channel=channel
+        )
+    else:
+        raise ValueError(f"Unknown backend {backend}")
+
+    for name, specs in found_conda_deps.items():
+        conda_deps[name].extend(specs)
+    # deduplicate
+    conda_deps = {name: list(dict.fromkeys(specs)) for name, specs in conda_deps.items()}
+    pypi_deps = {name: list(dict.fromkeys(specs)) for name, specs in pypi_deps.items()}
+    return conda_deps, pypi_deps

--- a/conda_pip/dependencies/grayskull.py
+++ b/conda_pip/dependencies/grayskull.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from logging import getLogger, ERROR
 from collections import defaultdict

--- a/conda_pip/dependencies/grayskull.py
+++ b/conda_pip/dependencies/grayskull.py
@@ -1,4 +1,3 @@
-
 import os
 from logging import getLogger, ERROR
 from collections import defaultdict
@@ -19,7 +18,12 @@ logger = getLogger(f"conda.{__name__}")
 # workaround for some weakref leak in souschef
 keep_refs_alive = []
 
-def _analyze_with_grayskull(*packages: str, prefer_on_conda=True, channel="conda-forge"):
+
+def _analyze_with_grayskull(
+    *packages: str,
+    prefer_on_conda: bool = True,
+    channel: str = "conda-forge",
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     conda_deps = defaultdict(list)
     pypi_deps = defaultdict(list)
     for package in packages:
@@ -44,12 +48,12 @@ def _analyze_with_grayskull(*packages: str, prefer_on_conda=True, channel="conda
 
 
 def _recursive_grayskull(
-    pkg_name,
-    pkg_version="",
-    conda_deps_map=None,
-    pypi_deps_map=None,
-    visited_pypi_map=None,
-):
+    pkg_name: str,
+    pkg_version: str = "",
+    conda_deps_map: dict[str, list[str]] | None = None,
+    pypi_deps_map: dict[str, list[str]] | None = None,
+    visited_pypi_map: dict[str, list[str]] | None = None,
+) -> tuple[dict[str, list[str]], dict[str, list[str]], dict[str, list[str]]]:
     conda_deps_map = conda_deps_map or defaultdict(list)
     pypi_deps_map = pypi_deps_map or defaultdict(list)
     visited_pypi_map = visited_pypi_map or defaultdict(list)
@@ -73,7 +77,10 @@ def _recursive_grayskull(
     return conda_deps_map, pypi_deps_map, visited_pypi_map
 
 
-def _analyze_one_with_grayskull(package, version=""):
+def _analyze_one_with_grayskull(
+    package: str,
+    version: str = "",
+) -> tuple[dict[str, str], dict[str, str], GrayskullConfiguration]:
     config = GrayskullConfiguration(name=package, version=version, is_strict_cf=True)
     try:
         with redirect_stdout(os.devnull), redirect_stderr(os.devnull):

--- a/conda_pip/dependencies/pip.py
+++ b/conda_pip/dependencies/pip.py
@@ -1,10 +1,11 @@
 import json
-from logging import DEBUG, getLogger
+import os
+from logging import getLogger
 from collections import defaultdict
 from subprocess import run
+from tempfile import NamedTemporaryFile
 
 from conda.exceptions import CondaError
-from grayskull.base.pkg_info import is_pkg_available
 
 from ..utils import get_env_python
 
@@ -12,39 +13,47 @@ logger = getLogger(f"conda.{__name__}")
 
 
 def _analyze_with_pip(
-    *packages,
-    prefer_on_conda=True,
-    channel="conda-forge",
-    prefix=None,
-    force_reinstall=False,
-):
+    *packages: str,
+    prefix: str | None = None,
+    force_reinstall: bool = False,
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    # pip can output to stdout via `--report -` (dash), but this
+    # creates issues on Windows due to undecodable characters on some
+    # project descriptions (e.g. charset-normalizer, amusingly), which
+    # makes pip crash internally. Probably a bug on their end.
+    # So we use a temporary file instead to work with bytes.
+    json_output = NamedTemporaryFile(suffix=".json", delete=False)
+    json_output.close()  # Prevent access errors on Windows
+
     cmd = [
-        get_env_python(prefix),
+        str(get_env_python(prefix)),
         "-mpip",
         "install",
         "--dry-run",
         "--ignore-installed",
         *(("--force-reinstall",) if force_reinstall else ()),
         "--report",
-        "-",  # this tells pip to print the report to stdout
-        "--quiet",  # this is needed so normal pip output doesn't get mixed with json
+        json_output.name,
         *packages,
     ]
-    process = run(cmd, capture_output=True, text=True, errors="replace")
+    process = run(cmd, capture_output=True, text=True)
     if process.returncode != 0:
         raise CondaError(
             f"Failed to analyze dependencies with pip:\n"
-            f"  command: {' '.join(map(str, cmd))}\n"
+            f"  command: {' '.join(cmd)}\n"
             f"  exit code: {process.returncode}\n"
             f"  stderr:\n{process.stderr}\n"
             f"  stdout:\n{process.stdout}\n"
         )
-    logger.debug(
-        "pip (%s) provided the following report:\n%s",
-        " ".join(map(str, cmd)),
-        process.stdout,
-    )
-    report = json.loads(process.stdout)
+    logger.debug("pip (%s) provided the following report:\n%s", " ".join(cmd), process.stdout)
+
+    with open(json_output.name, "rb") as f:
+        # We need binary mode because the JSON output might
+        # contain weird unicode stuff (as part of the project
+        # description or README).
+        report = json.loads(f.read())
+    os.unlink(json_output.name)
+
     deps_from_pip = defaultdict(list)
     conda_deps = defaultdict(list)
     for item in report["install"]:

--- a/conda_pip/dependencies/pip.py
+++ b/conda_pip/dependencies/pip.py
@@ -29,7 +29,7 @@ def _analyze_with_pip(*packages, prefer_on_conda=True, channel="conda-forge", pr
         if process.returncode != 0:
             raise CondaError(
                 f"Failed to analyze dependencies with pip:\n"
-                f"  command: {' '.join(cmd)}\n"
+                f"  command: {' '.join(map(str, cmd))}\n"
                 f"  exit code: {process.returncode}\n"
                 f"  stdout:\n{process.stdout}\n"
                 f"  stderr:\n{process.stderr}\n"

--- a/conda_pip/dependencies/pip.py
+++ b/conda_pip/dependencies/pip.py
@@ -36,8 +36,8 @@ def _analyze_with_pip(
             f"Failed to analyze dependencies with pip:\n"
             f"  command: {' '.join(map(str, cmd))}\n"
             f"  exit code: {process.returncode}\n"
-            f"  stdout:\n{process.stdout}\n"
             f"  stderr:\n{process.stderr}\n"
+            f"  stdout:\n{process.stdout}\n"
         )
     logger.debug(
         "pip (%s) provided the following report:\n%s",

--- a/conda_pip/dependencies/pip.py
+++ b/conda_pip/dependencies/pip.py
@@ -30,7 +30,7 @@ def _analyze_with_pip(
         "--quiet",  # this is needed so normal pip output doesn't get mixed with json
         *packages,
     ]
-    process = run(cmd, capture_output=True, text=True, errors="backslashreplace")
+    process = run(cmd, capture_output=True, text=True, errors="replace")
     if process.returncode != 0:
         raise CondaError(
             f"Failed to analyze dependencies with pip:\n"

--- a/conda_pip/dependencies/pip.py
+++ b/conda_pip/dependencies/pip.py
@@ -30,7 +30,7 @@ def _analyze_with_pip(
         "--quiet",  # this is needed so normal pip output doesn't get mixed with json
         *packages,
     ]
-    process = run(cmd, capture_output=True, text=True)
+    process = run(cmd, capture_output=True, text=True, errors="backslashreplace")
     if process.returncode != 0:
         raise CondaError(
             f"Failed to analyze dependencies with pip:\n"

--- a/conda_pip/dependencies/pip.py
+++ b/conda_pip/dependencies/pip.py
@@ -1,0 +1,58 @@
+import json
+import sys
+from logging import getLogger, ERROR
+from collections import defaultdict
+from subprocess import run
+from tempfile import NamedTemporaryFile
+
+from conda.exceptions import CondaError
+from grayskull.base.pkg_info import is_pkg_available
+
+
+getLogger("requests").setLevel(ERROR)
+getLogger("urllib3").setLevel(ERROR)
+logger = getLogger(f"conda.{__name__}")
+
+
+def _analyze_with_pip(*packages, prefer_on_conda=True, channel="conda-forge"):
+    with NamedTemporaryFile("w+") as f:
+        cmd = [
+            sys.executable,
+            "-mpip",
+            "install",
+            "--dry-run",
+            "--report",
+            f.name,
+            *packages,
+        ]
+        process = run(cmd, capture_output=True, text=True)
+        if process.returncode != 0:
+            raise CondaError(
+                f"Failed to analyze dependencies with pip:\n"
+                f"  command: {' '.join(cmd)}\n"
+                f"  exit code: {process.returncode}\n"
+                f"  stdout:\n{process.stdout}\n"
+                f"  stderr:\n{process.stderr}\n"
+            )
+        f.seek(0)
+        report = json.load(f)
+
+    deps_from_pip = defaultdict(list)
+    conda_deps = defaultdict(list)
+    for item in report["install"]:
+        metadata = item["metadata"]
+        logger.debug("Analyzing %s", metadata["name"])
+        logger.debug("  metadata: %s", json.dumps(metadata, indent=2))
+        deps_from_pip[metadata["name"]].append(f"{metadata['name']}=={metadata['version']}")
+        if python_version := metadata.get("requires_python"):
+            conda_deps["python"].append(f"python {python_version}")
+
+    deps_from_pip = {name: list(dict.fromkeys(specs)) for name, specs in deps_from_pip.items()}
+    
+    pypi_deps = defaultdict(list)
+    for depname, deps in deps_from_pip.items():
+        if is_pkg_available(depname, channel=channel):
+            conda_deps[depname].extend(deps)  # TODO: Map pypi name to conda name(s)
+        else:
+            pypi_deps[depname].extend(deps)
+    return conda_deps, pypi_deps

--- a/conda_pip/dependencies/pip.py
+++ b/conda_pip/dependencies/pip.py
@@ -65,11 +65,4 @@ def _analyze_with_pip(
             conda_deps["python"].append(f"python {python_version}")
 
     deps_from_pip = {name: list(dict.fromkeys(specs)) for name, specs in deps_from_pip.items()}
-
-    pypi_deps = defaultdict(list)
-    for depname, deps in deps_from_pip.items():
-        if prefer_on_conda and is_pkg_available(depname, channel=channel):
-            conda_deps[depname].extend(deps)  # TODO: Map pypi name to conda name(s)
-        else:
-            pypi_deps[depname].extend(deps)
-    return conda_deps, pypi_deps
+    return conda_deps, deps_from_pip

--- a/conda_pip/dependencies/pip.py
+++ b/conda_pip/dependencies/pip.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from logging import getLogger

--- a/conda_pip/main.py
+++ b/conda_pip/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from logging import getLogger
 from pathlib import Path

--- a/conda_pip/main.py
+++ b/conda_pip/main.py
@@ -30,7 +30,7 @@ def validate_target_env(path: Path, packages: Iterable[str]) -> Iterable[str]:
         raise CondaError(f"Target environment at {path} requires python>=3.2")
     if not list(pd.query("pip>=23.0.1")):
         raise CondaError(f"Target environment at {path} requires pip>=23.0.1")
-    
+
     packages_to_process = []
     for pkg in packages:
         spec = MatchSpec(pkg)
@@ -44,13 +44,13 @@ def validate_target_env(path: Path, packages: Iterable[str]) -> Iterable[str]:
 def run_conda_install(
     prefix: Path,
     specs: Iterable[MatchSpec],
-    dry_run=False,
-    quiet=False,
-    verbosity=0,
-    force_reinstall=False,
-    yes=False,
-    json=False,
-):
+    dry_run: bool = False,
+    quiet: bool = False,
+    verbosity: int = 0,
+    force_reinstall: bool = False,
+    yes: bool = False,
+    json: bool = False,
+) -> int:
     if not specs:
         return 0
 
@@ -80,14 +80,14 @@ def run_conda_install(
 
 def run_pip_install(
     prefix: Path,
-    specs,
-    upgrade=False,
-    dry_run=False,
-    quiet=False,
-    verbosity=0,
-    force_reinstall=False,
-    yes=False,
-):
+    specs: Iterable[str],
+    upgrade: bool = False,
+    dry_run: bool = False,
+    quiet: bool = False,
+    verbosity: int = 0,
+    force_reinstall: bool = False,
+    yes: bool = False,
+) -> int:
     if not specs:
         return 0
     command = [

--- a/conda_pip/main.py
+++ b/conda_pip/main.py
@@ -1,9 +1,7 @@
 import os
-import sys
-import sysconfig
 from logging import getLogger
 from pathlib import Path
-from subprocess import run, check_output
+from subprocess import run
 from typing import Iterable
 
 try:
@@ -12,51 +10,16 @@ except ImportError:
     from importlib_resources import files as importlib_files
 
 from conda.history import History
-from conda.base.context import context, locate_prefix_by_name
+from conda.base.context import context
 from conda.core.prefix_data import PrefixData
 from conda.cli.python_api import run_command
 from conda.exceptions import CondaError, CondaSystemExit
 from conda.models.match_spec import MatchSpec
 
+from .utils import get_env_python, get_externally_managed_path
+
 logger = getLogger(f"conda.{__name__}")
 HERE = Path(__file__).parent.resolve()
-
-
-def get_prefix(prefix: os.PathLike = None, name: str = None) -> Path:
-    if prefix:
-        return Path(prefix)
-    elif name:
-        return Path(locate_prefix_by_name(name))
-    else:
-        return Path(context.target_prefix)
-
-
-def get_env_python(prefix: os.PathLike = None) -> Path:
-    prefix = Path(prefix or sys.prefix)
-    if os.name == "nt":
-        return prefix / "python.exe"
-    return prefix / "bin" / "python"
-
-
-def get_env_stdlib(prefix: os.PathLike = None) -> Path:
-    prefix = Path(prefix or sys.prefix)
-    if str(prefix) == sys.prefix:
-        return Path(sysconfig.get_path("stdlib"))
-    return Path(check_output([get_env_python(prefix), "-c", "import sysconfig; print(sysconfig.get_paths()['stdlib'])"], text=True).strip())
-
-
-def get_externally_managed_path(prefix: os.PathLike = None) -> Path:
-    prefix = Path(prefix or sys.prefix)
-    if os.name == "nt":
-        yield Path(prefix, "Lib", "EXTERNALLY-MANAGED")
-    else:
-        found = False
-        for python_dir in sorted(Path(prefix, "lib").glob("python*")):
-            if python_dir.is_dir():
-                found = True
-                yield Path(python_dir, "EXTERNALLY-MANAGED")
-        if not found:
-            raise ValueError("Could not locate EXTERNALLY-MANAGED file")
 
 
 def validate_target_env(path: Path, packages: Iterable[str]) -> Iterable[str]:
@@ -67,7 +30,7 @@ def validate_target_env(path: Path, packages: Iterable[str]) -> Iterable[str]:
         raise CondaError(f"Target environment at {path} requires python>=3.2")
     if not list(pd.query("pip>=23.0.1")):
         raise CondaError(f"Target environment at {path} requires pip>=23.0.1")
-
+    
     packages_to_process = []
     for pkg in packages:
         spec = MatchSpec(pkg)

--- a/conda_pip/utils.py
+++ b/conda_pip/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import sysconfig

--- a/conda_pip/utils.py
+++ b/conda_pip/utils.py
@@ -4,8 +4,10 @@ import sysconfig
 from logging import getLogger
 from pathlib import Path
 from subprocess import check_output
+from typing import Iterator
 
 from conda.base.context import context, locate_prefix_by_name
+
 
 logger = getLogger(f"conda.{__name__}")
 
@@ -30,10 +32,19 @@ def get_env_stdlib(prefix: os.PathLike = None) -> Path:
     prefix = Path(prefix or sys.prefix)
     if str(prefix) == sys.prefix:
         return Path(sysconfig.get_path("stdlib"))
-    return Path(check_output([get_env_python(prefix), "-c", "import sysconfig; print(sysconfig.get_paths()['stdlib'])"], text=True).strip())
+    return Path(
+        check_output(
+            [
+                get_env_python(prefix),
+                "-c",
+                "import sysconfig; print(sysconfig.get_paths()['stdlib'])",
+            ],
+            text=True,
+        ).strip()
+    )
 
 
-def get_externally_managed_path(prefix: os.PathLike = None) -> Path:
+def get_externally_managed_path(prefix: os.PathLike = None) -> Iterator[Path]:
     prefix = Path(prefix or sys.prefix)
     if os.name == "nt":
         yield Path(prefix, "Lib", "EXTERNALLY-MANAGED")

--- a/conda_pip/utils.py
+++ b/conda_pip/utils.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import sysconfig
+from logging import getLogger
+from pathlib import Path
+from subprocess import check_output
+
+from conda.base.context import context, locate_prefix_by_name
+
+logger = getLogger(f"conda.{__name__}")
+
+
+def get_prefix(prefix: os.PathLike = None, name: str = None) -> Path:
+    if prefix:
+        return Path(prefix)
+    elif name:
+        return Path(locate_prefix_by_name(name))
+    else:
+        return Path(context.target_prefix)
+
+
+def get_env_python(prefix: os.PathLike = None) -> Path:
+    prefix = Path(prefix or sys.prefix)
+    if os.name == "nt":
+        return prefix / "python.exe"
+    return prefix / "bin" / "python"
+
+
+def get_env_stdlib(prefix: os.PathLike = None) -> Path:
+    prefix = Path(prefix or sys.prefix)
+    if str(prefix) == sys.prefix:
+        return Path(sysconfig.get_path("stdlib"))
+    return Path(check_output([get_env_python(prefix), "-c", "import sysconfig; print(sysconfig.get_paths()['stdlib'])"], text=True).strip())
+
+
+def get_externally_managed_path(prefix: os.PathLike = None) -> Path:
+    prefix = Path(prefix or sys.prefix)
+    if os.name == "nt":
+        yield Path(prefix, "Lib", "EXTERNALLY-MANAGED")
+    else:
+        found = False
+        for python_dir in sorted(Path(prefix, "lib").glob("python*")):
+            if python_dir.is_dir():
+                found = True
+                yield Path(python_dir, "EXTERNALLY-MANAGED")
+        if not found:
+            raise ValueError("Could not locate EXTERNALLY-MANAGED file")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - pip >=23.0.1
     - grayskull
     - importlib_resources
+    - conda-libmamba-solver
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
     - conda_pip.main
   commands:
     - conda pip --help
-    - python -c "from conda_pip.main import get_env_stdlib; assert (get_env_stdlib() / 'EXTERNALLY-MANAGED').exists()"
+    - python -c "from conda_pip.utils import get_env_stdlib; assert (get_env_stdlib() / 'EXTERNALLY-MANAGED').exists()"
     - pip install requests && exit 1 || exit 0
 
 about:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,14 +2,33 @@ import sys
 
 import pytest
 
+from conda.core.prefix_data import PrefixData
+from conda.models.match_spec import MatchSpec
 from conda.testing import CondaCLIFixture, TmpEnvFixture
-from conda.testing.integration import package_is_installed
 
 from conda_pip.dependencies import BACKENDS
 
+
 @pytest.mark.parametrize("backend", BACKENDS)
-@pytest.mark.parametrize("spec", ["numpy", "numpy=1.20"])
-def test_conda_pip_install_numpy(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture, spec: str, backend: str):
+@pytest.mark.parametrize(
+    "pypi_spec,conda_spec,channel",
+    [
+        ("numpy", "numpy", "conda-forge"),
+        ("numpy=1.20", "numpy=1.20", "conda-forge"),
+        # build was originally published as build in conda-forge
+        # and later renamed to python-build; conda-forge::build is
+        # only available til 0.7, but conda-forge::python-build has 1.x
+        ("build>=1", "python-build>=1", "conda-forge"),
+    ],
+)
+def test_conda_pip_install(
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+    pypi_spec: str,
+    conda_spec: str,
+    channel: str,
+    backend: str,
+):
     with tmp_env("python=3.9", "pip") as prefix:
         out, err, rc = conda_cli(
             "pip",
@@ -19,10 +38,14 @@ def test_conda_pip_install_numpy(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixt
             "install",
             "--backend",
             backend,
-            spec,
+            pypi_spec,
         )
         print(out)
         print(err, file=sys.stderr)
         assert rc == 0
-        assert spec in out
-        assert package_is_installed(str(prefix), spec)
+        assert MatchSpec(pypi_spec).name in out or MatchSpec(conda_spec).name in out
+        pd = PrefixData(str(prefix), pip_interop_enabled=channel == "pypi")
+        records = list(pd.query(conda_spec))
+        assert len(records) == 1
+        assert records[0].channel.name == channel
+        

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,9 +5,11 @@ import pytest
 from conda.testing import CondaCLIFixture, TmpEnvFixture
 from conda.testing.integration import package_is_installed
 
+from conda_pip.dependencies import BACKENDS
 
+@pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("spec", ["numpy", "numpy=1.20"])
-def test_conda_pip_install_numpy(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture, spec: str):
+def test_conda_pip_install_numpy(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture, spec: str, backend: str):
     with tmp_env("python=3.9", "pip") as prefix:
         out, err, rc = conda_cli(
             "pip",
@@ -15,6 +17,8 @@ def test_conda_pip_install_numpy(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixt
             prefix,
             "--yes",
             "install",
+            "--backend",
+            backend,
             spec,
         )
         print(out)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -9,7 +9,7 @@ from conda.testing import CondaCLIFixture, TmpEnvFixture
 from conda.testing.integration import package_is_installed
 from pytest_mock import MockerFixture
 
-from conda_pip.main import get_env_python, get_env_stdlib
+from conda_pip.utils import get_env_python, get_env_stdlib
 
 
 def test_pip_required_in_target_env(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture, monkeypatch):


### PR DESCRIPTION
Closes #6 

Needs:

- [x] Use `pip install --dry-run --report` as a solver
- [x] Map PyPI names to conda names. Note this include a collection of PyPI names being available as a single conda name (e.g. tensorflow), but also the opposite (pyqt in PyPI is actually PyQt + qt, but conda usually has alias packages).
- [x] Add tests