### PR TITLE
Normalize PyPI specs

### DIFF
--- a/conda_pip/cli.py
+++ b/conda_pip/cli.py
@@ -78,7 +78,7 @@ def execute(args: argparse.Namespace) -> int:
     packages_to_process = args.packages if args.force_reinstall else packages_not_installed
     if not packages_to_process:
         print("All packages are already installed.", file=sys.stderr)
-        return
+        return 0
 
     with Spinner("Analyzing dependencies", enabled=not args.quiet, json=args.json):
         conda_deps, pypi_deps = analyze_dependencies(

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -14,6 +14,8 @@ from conda.models.match_spec import MatchSpec
 from conda_libmamba_solver.index import LibMambaIndexHelper as Index
 from ruamel.yaml import YAML
 
+from ..utils import pypi_spec_variants
+
 yaml = YAML(typ="safe")
 logger = getLogger(f"conda.{__name__}")
 
@@ -109,14 +111,8 @@ def _is_pkg_on_conda(pypi_spec: str, channel: str = "conda-forge") -> tuple[bool
     Given a PyPI spec (name, version), try to find it on conda-forge.
     """
     index = Index(channels=[channel])
-    match_spec = MatchSpec(pypi_spec)
-    for name_variant in (
-        pypi_spec,
-        pypi_spec.lower().replace("-", "_"),
-        pypi_spec.lower().replace("_", "-"),
-        pypi_spec.lower(),
-    ):
-        conda_spec = _pypi_spec_to_conda_spec(str(MatchSpec(match_spec, name=name_variant)))
+    for spec_variant in pypi_spec_variants(pypi_spec):
+        conda_spec = _pypi_spec_to_conda_spec(spec_variant)
         records = index.search(conda_spec)
         if records:
             return True, conda_spec

--- a/conda_pip/dependencies/__init__.py
+++ b/conda_pip/dependencies/__init__.py
@@ -41,12 +41,13 @@ def analyze_dependencies(
         match_spec = MatchSpec(package)
         pkg_name = match_spec.name
         # pkg_version = match_spec.version
-        if prefer_on_conda and _is_pkg_on_conda(pkg_name, channel=channel):
-            # TODO: check if version is available too
-            logger.info("Package %s is available on %s. Skipping analysis.", pkg_name, channel)
-            conda_spec = _pypi_spec_to_conda_spec(package)
-            conda_deps[pkg_name].append(conda_spec)
-            continue
+        if prefer_on_conda:
+            pkg_is_on_conda, conda_spec = _is_pkg_on_conda(pkg_name, channel=channel)
+            if pkg_is_on_conda:
+                # TODO: check if version is available too
+                logger.info("Package %s is available on %s as %s. Skipping analysis.", pkg_name, channel, conda_spec)
+                conda_deps[pkg_name].append(conda_spec)
+                continue
         needs_analysis.append(package)
 
     if not needs_analysis:
@@ -92,24 +93,34 @@ def _classify_dependencies(
     pypi_deps = defaultdict(list)
     conda_deps = defaultdict(list)
     for depname, deps in deps_from_pypi.items():
-        if prefer_on_conda and _is_pkg_on_conda(depname, channel=channel):
-            conda_depname = _pypi_spec_to_conda_spec(depname, channel=channel).name
-            deps_mapped_to_conda = [_pypi_spec_to_conda_spec(dep, channel=channel) for dep in deps]
-            conda_deps[conda_depname].extend(deps_mapped_to_conda)
-        else:
-            pypi_deps[depname].extend(deps)
+        if prefer_on_conda:
+            on_conda, conda_depname = _is_pkg_on_conda(depname, channel=channel)
+            if on_conda:
+                deps_mapped_to_conda = [_pypi_spec_to_conda_spec(dep, channel=channel) for dep in deps]
+                conda_deps[conda_depname].extend(deps_mapped_to_conda)
+                continue
+        pypi_deps[depname].extend(deps)
     return conda_deps, pypi_deps
 
 
 @lru_cache(maxsize=None)
-def _is_pkg_on_conda(pypi_spec: str, channel: str = "conda-forge"):
+def _is_pkg_on_conda(pypi_spec: str, channel: str = "conda-forge") -> tuple[bool, str]:
     """
     Given a PyPI spec (name, version), try to find it on conda-forge.
     """
-    conda_spec = _pypi_spec_to_conda_spec(pypi_spec)
     index = Index(channels=[channel])
-    records = index.search(conda_spec)
-    return bool(records)
+    match_spec = MatchSpec(pypi_spec)
+    for name_variant in (
+        pypi_spec,
+        pypi_spec.lower().replace("-", "_"),
+        pypi_spec.lower().replace("_", "-"),
+        pypi_spec.lower(),
+    ):
+        conda_spec = _pypi_spec_to_conda_spec(str(MatchSpec(match_spec, name=name_variant)))
+        records = index.search(conda_spec)
+        if records:
+            return True, conda_spec
+    return False, pypi_spec
 
 
 @lru_cache(maxsize=None)

--- a/conda_pip/main.py
+++ b/conda_pip/main.py
@@ -36,10 +36,12 @@ def validate_target_env(path: Path, packages: Iterable[str]) -> Iterable[str]:
     packages_to_process = []
     for pkg in packages:
         spec = MatchSpec(pkg)
-        if list(pd.query(spec)):
-            logger.warning("package %s is already installed; ignoring", spec)
-            continue
-        packages_to_process.append(pkg)
+        for name_variant in (spec.name, spec.name.replace("-", "_"), spec.name.replace("_", "-")):
+            if list(pd.query(MatchSpec(spec, name=name_variant))):
+                logger.warning("package %s is already installed; ignoring", spec)
+                break
+        else:
+            packages_to_process.append(pkg)
     return packages_to_process
 
 

--- a/conda_pip/main.py
+++ b/conda_pip/main.py
@@ -18,7 +18,7 @@ from conda.cli.python_api import run_command
 from conda.exceptions import CondaError, CondaSystemExit
 from conda.models.match_spec import MatchSpec
 
-from .utils import get_env_python, get_externally_managed_path
+from .utils import get_env_python, get_externally_managed_path, pypi_spec_variants
 
 logger = getLogger(f"conda.{__name__}")
 HERE = Path(__file__).parent.resolve()
@@ -35,10 +35,9 @@ def validate_target_env(path: Path, packages: Iterable[str]) -> Iterable[str]:
 
     packages_to_process = []
     for pkg in packages:
-        spec = MatchSpec(pkg)
-        for name_variant in (spec.name, spec.name.replace("-", "_"), spec.name.replace("_", "-")):
-            if list(pd.query(MatchSpec(spec, name=name_variant))):
-                logger.warning("package %s is already installed; ignoring", spec)
+        for spec_variant in pypi_spec_variants(pkg):
+            if list(pd.query(spec_variant)):
+                logger.warning("package %s is already installed; ignoring", pkg)
                 break
         else:
             packages_to_process.append(pkg)

--- a/conda_pip/utils.py
+++ b/conda_pip/utils.py
@@ -63,8 +63,11 @@ def get_externally_managed_path(prefix: os.PathLike = None) -> Iterator[Path]:
 def pypi_spec_variants(spec_str: str) -> Iterator[str]:
     yield spec_str
     spec = MatchSpec(spec_str)
+    seen = {spec_str}
     for name_variant in (
         spec.name.replace("-", "_"),
         spec.name.replace("_", "-"),
-    ):
-        yield str(MatchSpec(spec, name=name_variant))
+    ):  
+        if name_variant not in seen:  # only yield if actually different
+            yield str(MatchSpec(spec, name=name_variant))
+            seen.add(name_variant)

--- a/conda_pip/utils.py
+++ b/conda_pip/utils.py
@@ -9,6 +9,7 @@ from subprocess import check_output
 from typing import Iterator
 
 from conda.base.context import context, locate_prefix_by_name
+from conda.models.match_spec import MatchSpec
 
 
 logger = getLogger(f"conda.{__name__}")
@@ -58,3 +59,12 @@ def get_externally_managed_path(prefix: os.PathLike = None) -> Iterator[Path]:
                 yield Path(python_dir, "EXTERNALLY-MANAGED")
         if not found:
             raise ValueError("Could not locate EXTERNALLY-MANAGED file")
+
+def pypi_spec_variants(spec_str: str) -> Iterator[str]:
+    yield spec_str
+    spec = MatchSpec(spec_str)
+    for name_variant in (
+        spec.name.replace("-", "_"),
+        spec.name.replace("_", "-"),
+    ):
+        yield str(MatchSpec(spec, name=name_variant))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -19,6 +19,8 @@ from conda_pip.dependencies import BACKENDS
         # and later renamed to python-build; conda-forge::build is
         # only available til 0.7, but conda-forge::python-build has 1.x
         ("build>=1", "python-build>=1", "conda-forge"),
+        # ib-insync is only available with dashes, not with underscores
+        ("ib_insync", "ib-insync", "conda-forge"),
         # these won't be ever published in conda-forge, I guess
         ("aaargh", None, "pypi"),
         ("5-exercise-upload-to-pypi", None, "pypi"),
@@ -67,15 +69,14 @@ def test_conda_pip_install(
         assert records[0].channel.name == channel
 
 
-@pytest.mark.parametrize("spec", ("pytest-cov", "pytest_cov", "PyTest-Cov"))
 def test_spec_normalization(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
-    spec: str,
 ):
     with tmp_env("python=3.9", "pip", "pytest-cov") as prefix:
-        out, err, rc = conda_cli("pip", "-p", prefix, "--yes", "install", spec)
-        print(out)
-        print(err, file=sys.stderr)
-        assert rc == 0
-        assert "All packages are already installed." in out + err
+        for spec in ("pytest-cov", "pytest_cov", "PyTest-Cov"):
+            out, err, rc = conda_cli("pip", "--dry-run", "-p", prefix, "--yes", "install", spec)
+            print(out)
+            print(err, file=sys.stderr)
+            assert rc == 0
+            assert "All packages are already installed." in out + err

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -53,7 +53,7 @@ def test_conda_pip_install(
             for name in (
                 MatchSpec(pypi_spec).name,
                 MatchSpec(pypi_spec).name.replace("-", "_"),  # pip normalizes this
-                MatchSpec(conda_spec).name
+                MatchSpec(conda_spec).name,
             )
         )
         PrefixData._cache_.clear()
@@ -65,4 +65,17 @@ def test_conda_pip_install(
             records = list(pd.query(conda_spec))
         assert len(records) == 1
         assert records[0].channel.name == channel
-        
+
+
+@pytest.mark.parametrize("spec", ("pytest-cov", "pytest_cov", "PyTest-Cov"))
+def test_spec_normalization(
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+    spec: str,
+):
+    with tmp_env("python=3.9", "pip", "pytest-cov") as prefix:
+        out, err, rc = conda_cli("pip", "-p", prefix, "--yes", "install", spec)
+        print(out)
+        print(err, file=sys.stderr)
+        assert rc == 0
+        assert "All packages are already installed." in out + err


### PR DESCRIPTION
Both `conda` and PyPI packages are case-insensitive. PyPI packages additionally disregard dashes and underscores: they are considered equivalent. However, `conda` does distinguish those.

As a result, when a user installs `a-package` and `a_package`, `pip` produces the same result but `conda` might not. This means that if the PyPI name is not on the mappings, we need to try some variants in addition to the original name (dashes as underscores, underscores as hashes).

For the sake of simplicity, I'll assume there are no mixed dash-underscore packages on conda-forge.